### PR TITLE
LPS-69285 Add groupId as a parameter so the SiteMembershipsDisplayCon…

### DIFF
--- a/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/web-experience/site/site-admin-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -120,6 +120,7 @@ request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 
 					PortletURL assignMembersURL = PortalUtil.getControlPanelPortletURL(request, portletId, PortletRequest.RENDER_PHASE);
 
+					assignMembersURL.setParameter("groupId", String.valueOf(group.getGroupId()));
 					assignMembersURL.setParameter("redirect", currentURL);
 					%>
 


### PR DESCRIPTION
…text in the site-memberships-web module knows about the correct group

Hey Dustin,

Since Jonathan is out next week, I am sending this PR to you.

@alec-shay

Notes from Alec:

> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-23296
> https://issues.liferay.com/browse/LPS-69285
> 
> When going to Control Panel -> Sites, selecting one site, then clicking the "x users" link in the info panel (clicking the 'i' button), it loads the Site Membership page for the wrong group (it uses the groupId for the Control Panel group).
> 
> Passing the groupId as a parameter to the URL in info_panel.jsp allows it to determine the group selected properly when the jsp's in the site-admin-web module try to load it from a SiteMembershipDisplayContext object.