### PR TITLE
LPS-69293 Other Users can now see Locked Icon for checked-out DM files

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_vertical_card.jspf
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/file_entry_vertical_card.jspf
@@ -27,7 +27,7 @@
 				<aui:icon cssClass="icon-monospaced" image="shortcut" markupView="lexicon" message="shortcut" />
 			</div>
 		</c:when>
-		<c:when test="<%= fileEntry.hasLock() %>">
+		<c:when test="<%= fileEntry.isCheckedOut() %>">
 			<div class="file-icon-color-0 sticker sticker-right">
 				<aui:icon cssClass="icon-monospaced" image="lock" markupView="lexicon" message="locked" />
 			</div>


### PR DESCRIPTION
/cc @NolanChan

Notes from Nolan:
>Other Users can now see Locked Icon for checked-out DM files
>
>Code originally used hasLock which determined whether the logged-in user had the lock. Instead switching to isCheckedOut as this returns whether the file is checked out regardless of user