### PR TITLE
LPS-69854

### DIFF
--- a/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_modal.scss
@@ -35,6 +35,13 @@
 	overflow: hidden;
 }
 
+@media only screen and (max-device-width: 1024px) {
+	.modal-open {
+		overflow: visible !important;
+		position: fixed;
+	}
+}
+
 .portal-popup {
 	.columns-max > .portlet-layout.row {
 		margin-left: 0;


### PR DESCRIPTION
commit msg: background no longer scrolls when trying to scroll modal window on smaller media

Notes: 
(`frontend-theme-unstyled/.../_modals.scss` is automatically generated and not on the repo, so a screenshot is included) 

It seems from the screenshot below and in AUI-1336 that `.modal-open` was created to stop the bad scrolling problem. Building upon this class, it seems that keeping the body position fixed is the most straightforward way of making sure that the background does not move when the user scrolls the modal. This does some weird formatting to the body but `overflow: visible` seems to fix the most obvious issues. I've done some minor testing on all different types of devices, but further testing is necessary.

<img width="1426" alt="screen shot 2016-12-22 at 5 23 24 pm" src="https://cloud.githubusercontent.com/assets/1487616/21507357/658931f4-cc2c-11e6-8ed6-9e3e5fa9ea05.png">