### PR TITLE
LPS-69852 address where scheduleEntry trigger is not set

### DIFF
--- a/modules/apps/foundation/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/foundation/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -928,7 +928,9 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 
 			StorageType storageType = StorageType.MEMORY_CLUSTERED;
 
-			if (schedulerEntry == null) {
+			if ((schedulerEntry == null) ||
+				(schedulerEntry.getTrigger() == null)) {
+
 				return null;
 			}
 


### PR DESCRIPTION
Hi @dustinryerson,

Original ticket: [LPP-23620](https://issues.liferay.com/browse/LPP-23620)
Forum Post: [Changes to MEMORY_CLUSTERED jobs cause cluster nodes to fail startup](https://in.liferay.com/web/support/forums/-/message_boards/message/27667801)

**Main Issue**
Currently, MEMORY_CLUSTERED jobs are throwing SchedulerExceptions when certain properties are set.
For Example:
- Announcements - Portal Properties
    - `announcements.entry.check.interval=-1`
- LDAP - System Settings
    - Setting **import-interval = -1** in the LDAP configuratio using System Settings in Liferay DXP

This issue was introduced after changes from [LPS-58449](https://issues.liferay.com/browse/LPS-58449), which refactored the scheduler.

**Fix - Details**
This fix was made based on the stipulation that a scheduled job should not be scheduled if the quartz trigger is not set.

In our case, a quartz trigger is not set when the **time-interval** is less than 0.
For our examples, the **time-interval** is set to **-1**.
Reference: [QuartzTriggerFactory.java#L50](https://github.com/liferay/liferay-portal-ee/blob/fix-pack-de-9-7010/modules/apps/foundation/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzTriggerFactory.java#L50)

----
**Note**
Preston mentioned that this pull request should also be reviewed by Tina, since she works on many fixes involving the scheduler and clustering.

Please let me know if you have any questions.
Thanks!