### PR TITLE
LPS-70366

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/LoginPostAction.java
+++ b/portal-impl/src/com/liferay/portal/events/LoginPostAction.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.MessageBusUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.util.PrefsPropsUtil;
@@ -59,6 +60,14 @@ public class LoginPostAction extends Action {
 			// Language
 
 			session.removeAttribute(Globals.LOCALE_KEY);
+
+			// Password Expiring Check
+
+			if (UserLocalServiceUtil.isPasswordExpiringSoon(
+					PortalUtil.getUser(request))) {
+
+				SessionMessages.add(request, "passwordExpiringSoon");
+			}
 
 			// Live users
 

--- a/portal-web/docroot/html/common/themes/password_expiring_soon.jspf
+++ b/portal-web/docroot/html/common/themes/password_expiring_soon.jspf
@@ -14,13 +14,15 @@
  */
 --%>
 
-<c:if test="<%= themeDisplay.isSignedIn() && UserLocalServiceUtil.isPasswordExpiringSoon(user) %>">
-	<aui:script use="liferay-notice">
-		new Liferay.Notice(
+<c:if test='<%= SessionMessages.contains(request, "passwordExpiringSoon") %>'>
+	<aui:script use="liferay-alert">
+		new Liferay.Notification(
 			{
-				closeText: '<liferay-ui:message key="close" />',
-				content: '<liferay-ui:message key="warning-your-password-will-expire-soon" />',
-				toggleText: false
+				closeable: true,
+				destroyOnHide: false,
+				message: '<liferay-ui:message key="warning-your-password-will-expire-soon" />',
+				render: true,
+				type: 'warning'
 			}
 		);
 	</aui:script>


### PR DESCRIPTION
Progression from https://github.com/Robert-Frampton/liferay-portal/pull/352

The problems that I'm trying to address in this PR are twofold:

1. Notice.js was formatting itself really badly in DXP, and given that it's deprecated I opted to move this code over to Notification.js

2. Brian and Tsubasa are concerned that the repetitive nature of the password notifications will be extremely annoying, to which I agree. As such, we are moving the password expiration check to the `LoginPostAction` so that the notification will appear only once every login. This should stop the repetitive appearance.

I assumed that the user was logged in during the `PostLoginAction`, so I didn't include the `themeDisplay.isSignedIn()` check