### PR TITLE
LPS-71041 on IE11 fields can now be accessed in modal iframe popups

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler.js
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler.js
@@ -230,12 +230,6 @@ AUI.add(
 						instance.load();
 					},
 
-					_afterAddEventModalLoad: function(event) {
-						var instance = this;
-
-						event.target.node.getDOMNode().contentWindow.focus();
-					},
-
 					_afterDateChange: function(event) {
 						var instance = this;
 
@@ -407,12 +401,6 @@ AUI.add(
 								},
 								title: Liferay.Language.get('new-calendar-booking'),
 								uri: Lang.sub(editCalendarBookingURL, data)
-							},
-							function(modal) {
-								modal.iframe.on(
-									'load',
-									A.bind(instance._afterAddEventModalLoad, instance)
-								);
 							}
 						);
 					},

--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -1793,6 +1793,15 @@
 		function(config, callback) {
 			var dialog = Window.getWindow(config);
 
+			if (dialog.iframe) {
+				dialog.iframe.on(
+					'load',
+					function (event) {
+						event.target.node.getDOMNode().contentWindow.focus();
+					}
+				);
+			}
+
 			if (Lang.isFunction(callback)) {
 				callback(dialog);
 			}


### PR DESCRIPTION
I choose to put the fix in _openWindowProvider because it is in this method that the `window` is actually retrieved.

https://issues.liferay.com/browse/LPS-71041
https://issues.liferay.com/browse/LPP-24244