### PR TITLE
LPS-71856 CKEditor no longer displays wrong help text in toolbar

### DIFF
--- a/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_accessibility.scss
+++ b/modules/apps/foundation/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_accessibility.scss
@@ -24,36 +24,28 @@ td.stretch {
 }
 
 .cke_toolbar {
-	&.cke_toolbar__a11yhelpbtn {
-		float: right;
-
-		.cke_toolgroup, .cke_toolgroup:hover {
-			border-width: 0;
-			margin-bottom: 0;
-			margin-top: 5px;
+	.cke_button__a11ybtn {
+		.cke_button_icon {
+			display: none;
 		}
 
-		.cke_button {
-			.cke_button_icon {
-				display: none;
-			}
+		.cke_button_label {
+			display: inline;
+		}
 
-			.cke_button_label {
-				display: inline;
-
-				&:after {
-					border: 1px solid transparent;
-					content: 'Alt+0';
-					margin-left: 5px;
-					padding: 3px;
-				}
+		.cke_button__a11ybtn_label {
+			&:after {
+				border: 1px solid transparent;
+				content: 'Alt+0';
+				margin-left: 5px;
+				padding: 3px;
 			}
 		}
 	}
 }
 
 .mac {
-	.cke_toolbar.cke_toolbar__a11yhelpbtn .cke_button .cke_button_label:after {
+	.cke_toolbar .cke_button__a11ybtn .cke_button__a11ybtn_label:after {
 		content: 'Option+0';
 	}
 }

--- a/modules/apps/foundation/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/a11yhelpbtn/plugin.js
+++ b/modules/apps/foundation/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/a11yhelpbtn/plugin.js
@@ -14,23 +14,6 @@
 						}
 					);
 				}
-
-				editor.on(
-					'uiSpace',
-					function(event) {
-						var toolbarHTML = event.data.html;
-
-						var a11ybtnIndex = toolbarHTML.indexOf('cke_button__a11ybtn');
-
-						if (a11ybtnIndex !== -1) {
-							var a11ToolbarIndex = toolbarHTML.lastIndexOf('class="cke_toolbar"', a11ybtnIndex);
-
-							var toolbarText = toolbarHTML.substr(a11ToolbarIndex).replace('class="cke_toolbar"', 'class="cke_toolbar cke_toolbar__a11yhelpbtn"');
-
-							event.data.html = toolbarHTML.substr(0, a11ToolbarIndex) + toolbarText;
-						}
-					}
-				);
 			}
 		}
 	);

--- a/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/_extras.scss
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/_extras.scss
@@ -297,17 +297,12 @@ body > .lfr-menu-list ul, .active-area-proxy, .entry-display-style .entry-thumbn
 }
 
 .cke_toolbar {
-	&.cke_toolbar__a11yhelpbtn {
-		.cke_toolgroup, .cke_toolgroup:hover {
-			box-shadow: initial;
-		}
-
-		.cke_button {
+		.cke_button__a11ybtn {
 			&:hover {
 				box-shadow: none;
 			}
 
-			.cke_button_label {
+			.cke_button__a11ybtn_label {
 				&:after {
 					@include background-image(linear-gradient(#FFF, #E4E4E4));
 					border-radius: 2px;
@@ -318,7 +313,6 @@ body > .lfr-menu-list ul, .active-area-proxy, .entry-display-style .entry-thumbn
 				}
 			}
 		}
-	}
 }
 
 /* ---------- Switches ---------- */

--- a/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_accessibility.scss
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_accessibility.scss
@@ -1,20 +1,4 @@
-.cke_toolbar {
-	&.cke_toolbar__a11yhelpbtn {
-		.cke_toolgroup, .cke_toolgroup:hover {
-			background: transparent;
-		}
-
-		.cke_button {
-			&:hover {
-				background: transparent;
-			}
-
-			.cke_button_label {
-				&:after {
-					border-color: #A6A6A6;
-					font-family: "Courier New", Courier, "Lucida Sans Typewriter", "Lucida Typewriter", monospace;
-				}
-			}
-		}
-	}
+.cke_toolbar .cke_button__a11ybtn .cke_button__a11ybtn_label:after {
+	border-color: #A6A6A6;
+	font-family: "Courier New", Courier, "Lucida Sans Typewriter", "Lucida Typewriter", monospace;
 }


### PR DESCRIPTION
The original intention of the `Alt/Option+0` button was to be placed alongside the "Help" text to signify that `Alt/Option+0` was the shortcut to bring up the Help Modal. This was created in LPS-44056: 

![help_button_before](https://cloud.githubusercontent.com/assets/1487616/24926171/8bee6ea6-1eaf-11e7-9058-d937fdaa0b12.png)

However, the fix was a bit hacky and included relying on injecting HTML at a particular CSS class which is no longer guaranteed. The main assumption was that the Help Plugin would be residing in it's own toolbar, which is no longer the case for BBCode or Creole's CKeditor options. As such, I'm modifying the help button to display the help text in-place, which should simplify the code. It looks a bit different, but I don't believe we can code up the original intention of LPS-44056 given how the plugins are structured.

CKeditor:
![screen shot 2017-04-11 at 10 48 33 am](https://cloud.githubusercontent.com/assets/1487616/24926265/e601d036-1eaf-11e7-8681-b553c9fb422e.png)


CKeditor_bbcode:
<img width="1061" alt="screen shot 2017-04-11 at 12 11 58 pm" src="https://cloud.githubusercontent.com/assets/1487616/24926363/2eb064e6-1eb0-11e7-98cf-f35eb984ac4f.png">
