### PR TITLE
LPP-25030

### DIFF
--- a/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
@@ -225,6 +225,8 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 				for (var i = 1; i < keys.length; i++) {
 					var key = keys[i];
 
+					var field = A.one('#<portlet:namespace />' + key);
+
 					var currentFieldValue = fieldsMap[key];
 
 					var optionalFieldError = A.one('#<portlet:namespace />fieldOptionalError' + key);
@@ -239,6 +241,8 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 							optionalFieldError.show();
 							optionalFieldError.replace(optionalFieldError);
 						}
+
+						field.attr('aria-invalid', true);
 					}
 					else if (!fieldValidationFunctions[key](currentFieldValue, fieldsMap)) {
 						validationErrors = true;
@@ -253,6 +257,8 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 							validationError.show();
 							validationError.replace(validationError);
 						}
+
+						field.attr('aria-invalid', true);
 					}
 					else {
 						if (optionalFieldError) {
@@ -262,6 +268,8 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 						if (validationError) {
 							validationError.hide();
 						}
+
+						field.attr('aria-invalid', false);
 					}
 				}
 

--- a/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
@@ -66,14 +66,14 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 				<liferay-ui:error key='<%= "error" + fieldLabel %>' message="<%= fieldValidationErrorMessage %>" />
 
 				<c:if test="<%= Validator.isNotNull(fieldValidationScript) %>">
-					<div class="hide" id="<portlet:namespace />validationError<%= fieldName %>">
+					<div class="hide" id="<portlet:namespace />validationError<%= fieldName %>" role="alert">
 						<span class="alert alert-danger"><%= fieldValidationErrorMessage %></span>
 					</div>
 				</c:if>
 			</c:if>
 
 			<c:if test="<%= !fieldOptional %>">
-				<div class="hide" id="<portlet:namespace />fieldOptionalError<%= fieldName %>">
+				<div class="hide" id="<portlet:namespace />fieldOptionalError<%= fieldName %>" role="alert">
 					<span class="alert alert-danger"><liferay-ui:message key="this-field-is-mandatory" /></span>
 				</div>
 			</c:if>
@@ -237,6 +237,7 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 
 						if (optionalFieldError) {
 							optionalFieldError.show();
+							optionalFieldError.replace(optionalFieldError);
 						}
 					}
 					else if (!fieldValidationFunctions[key](currentFieldValue, fieldsMap)) {
@@ -250,6 +251,7 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 
 						if (validationError) {
 							validationError.show();
+							validationError.replace(validationError);
 						}
 					}
 					else {


### PR DESCRIPTION
Original Ticket: [LPS-72242](https://issues.liferay.com/browse/LPS-72242)

Hi @dustinryerson,

As discussed, this pull request resolves two issues:
1. JAWS screen reader now announces the error message(s) when validation shows invalid fields
    * Commit: https://github.com/dustinryerson/liferay-portal/commit/13b799b7037fd284cda22c7f1ce2fc79c9839bb5
2. JAWS screen reader also announces that an invalid field is invalid when the field is selected.
    * Commit: https://github.com/dustinryerson/liferay-portal/commit/fb7931f23b19a139dfc26de3ff1611f19e156acf

**Notes: Approach for this fix**
Our initial approach for this fix was to convert the error messages to utilize the `<aui:validator/>` tag.  But, we eventually realized that the `<aui:validator/>` could not accommodate the features provided by the Web Form portlet. 

For example, the Web Form portlet can:
* Assign a **paragraph block** as a field, not just input fields
* Assign special validation to each field, in addition to having a field as "**required**"
    * Reference: [How to utilize the validation feature within the Web Form Portlet](https://customer.liferay.com/documentation/knowledge-base/-/kb/14467)
* Assign special validation to each field, even a **paragraph block** field
* Run special validation on fields that can be checked, even when it is unchecked.
    * AUI validator does not validate input fields that can be checked when they are "**unchecked**".
        * Example: Checkbox, radio buttons

Eventually, we decided to focus on resolving the main issue: JAWS screen reader does not announce the error messages presented by the Web Form portlet.  

The main reason for this behavior is due to how the error messages are shown.  Currently, the messages are shown/dismissed by modifying the CSS via javascript to show or hide the element.  This commonly does not work well with screen readers.

Our current approach resolves this issue by making sure that the error message is re-introduced into the DOM when being shown, instead of just making it visible via CSS, which allows the screen reader to detect the new message.

----

Feel free to reach out if you have any questions.
Thanks!