### PR TITLE
LPS-73370

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_localized/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/init.jsp
@@ -88,7 +88,7 @@ if (!Validator.isNull(languageId)) {
 
 List<String> languageIds = new ArrayList<String>();
 
-String fieldName = name + fieldSuffix;
+String fieldName = HtmlUtil.getAUICompatibleId(name) + fieldSuffix;
 
 Exception exception = (Exception)request.getAttribute("liferay-ui:error:exception");
 String focusField = (String)request.getAttribute("liferay-ui:error:focusField");


### PR DESCRIPTION
Hi @dustinryerson. This issue was reported by a customer. A short reasoning for the pull request is the following. When no value of id is set for the taglib, it takes the value of name in InputLocalizedTag.java and it is used with getAUICompatibleId(id) in input_localized/init.jsp. The value of name must be applied the same method, getAUICompatibleId, when it is used in the definition of fieldName in init.jsp. Both id and fieldName will be used later in input_localized/page.jsp. Tell me if you have any questions. Thanks!