### PR TITLE
LPS-74181 Process the different styletags in the StripFilter

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/strip/StripFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/strip/StripFilter.java
@@ -253,10 +253,10 @@ public class StripFilter extends BasePortalFilter {
 
 	protected void processCSS(
 			HttpServletRequest request, HttpServletResponse response,
-			CharBuffer charBuffer, Writer writer)
+			CharBuffer charBuffer, Writer writer, char[] openTag)
 		throws Exception {
 
-		outputOpenTag(charBuffer, writer, _MARKER_STYLE_OPEN);
+		outputOpenTag(charBuffer, writer, openTag);
 
 		int length = KMPSearch.search(
 			charBuffer, _MARKER_STYLE_CLOSE, _MARKER_STYLE_CLOSE_NEXTS);
@@ -656,15 +656,24 @@ public class StripFilter extends BasePortalFilter {
 
 					continue;
 				}
-				else if (hasMarker(charBuffer, _MARKER_STYLE_OPEN) ||
-						 hasMarker(
-							 charBuffer,
-							 _MARKER_STYLE_DATA_SENNA_TRACK_PERMANENT) ||
-						 hasMarker(
-							 charBuffer,
-							 _MARKER_STYLE_DATA_SENNA_TRACK_TEMPORARY)) {
+				else if (hasMarker(charBuffer, _MARKER_STYLE_OPEN)) {
+					processCSS(request, response, charBuffer, writer, 
+						_MARKER_STYLE_OPEN);
 
-					processCSS(request, response, charBuffer, writer);
+					continue;
+				}
+				else if (hasMarker(charBuffer, 
+							_MARKER_STYLE_DATA_SENNA_TRACK_PERMANENT)) {
+					processCSS(request, response, charBuffer, writer,
+						_MARKER_STYLE_DATA_SENNA_TRACK_PERMANENT);
+
+					continue;
+				}
+				else if (hasMarker(charBuffer, 
+							_MARKER_STYLE_DATA_SENNA_TRACK_TEMPORARY)) {
+
+					processCSS(request, response, charBuffer, writer,
+						_MARKER_STYLE_DATA_SENNA_TRACK_TEMPORARY);
 
 					continue;
 				}


### PR DESCRIPTION
/cc @omarxxn3 @leendertvanbeelen
The processCss function in the StripFilter should not asume the open tag. Besides the default style tag LPS-70791 added other possible tags. Those will generate broken html tags now