### PR TITLE
LPS-74548 Disable reordering while on mobile devices as scrolling up …

### DIFF
--- a/modules/apps/web-experience/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
+++ b/modules/apps/web-experience/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
@@ -568,6 +568,12 @@ public class LayoutsTreeImpl implements LayoutsTree {
 			themeDisplay.getPermissionChecker(), groupId,
 			ActionKeys.MANAGE_LAYOUTS);
 
+		boolean mobile = false;
+
+		if (request.getHeader("User-Agent").indexOf("Mobile") != -1) {
+			mobile = true;
+		}
+
 		for (LayoutTreeNode layoutTreeNode : layoutTreeNodes) {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
@@ -609,7 +615,7 @@ public class LayoutsTreeImpl implements LayoutsTree {
 			jsonObject.put("regularURL", layout.getRegularURL(request));
 			jsonObject.put(
 				"sortable",
-				hasManageLayoutsPermission &&
+				hasManageLayoutsPermission && !mobile &&
 				SitesUtil.isLayoutSortable(layout));
 			jsonObject.put("type", layout.getType());
 			jsonObject.put(


### PR DESCRIPTION
Hi Dustin,

Jonathan said to go ahead and send this directly to you since it deals with UI/UX

This fix disables the page reordering in the product menu while browsing on mobile devices. Scrolling up and down on a page while reordering is enabled becomes difficult without reordering the nodes.