### PR TITLE
CSS styling rules on non-IE browsers are being trimmed when .ie selector is found

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
@@ -633,7 +633,7 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 		AggregateFilter.class);
 
 	private static final Pattern _pattern = Pattern.compile(
-		"(\.ie|\.js\.ie)(([^,{]+)([^{}]))", Pattern.MULTILINE);
+		"(\\.ie|\\.js\\.ie)(([^,{]+)([^{}]))", Pattern.MULTILINE);
 
 	private ServletContext _servletContext;
 	private File _tempDir;

--- a/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
@@ -633,7 +633,7 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 		AggregateFilter.class);
 
 	private static final Pattern _pattern = Pattern.compile(
-		"^(\\.ie|\\.js\\.ie)([^}]*)}", Pattern.MULTILINE);
+		"(\.ie|\.js\.ie)(([^,{]+)([^{}]))", Pattern.MULTILINE);
 
 	private ServletContext _servletContext;
 	private File _tempDir;


### PR DESCRIPTION
Hi Dustin,

Thank you in advance for reviewing this pull request containing the new regex. 
Just one thing, with one regex we cannot cover the following example:
`.ie button:focus` `{`
    `color: rebeccapurple`
`}`
In this example, we have to remove the selector and also its definition and, in this case, I would like to ask you to provide a decision on whether we can introduce a second regex which will solve this use case or not.

Best regards,
Omar